### PR TITLE
Add usage to README and add tests with private data and fix a few bugs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,13 +41,16 @@ jobs:
 
       - name: Checkout bluemira-private-data
         uses: actions/checkout@v4
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           repository: "Fusion-Power-Plant-Framework/bluemira-private-data"
           ssh-key: ${{ secrets.BLUEMIRA_PRIVATE_DATA_DEPLOY_KEY }}
           path: "./tests/test_data/private"
 
       - name: Run all tests with coverage
-        run: hatch run test:tests-cov
+        env:
+          PRIVATE: ${{ github.event.pull_request.head.repo.fork  && 'tests-cov' || 'tests-cov-private' }}
+        run: hatch run test:${PRIVATE}
 
   # docs:
   #   runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -25,3 +25,21 @@ pip install git+https://github.com/Fusion-Power-Plant-Framework/eqdsk.git
 ```
 
 For a developer setup please see [CONTRIBUTING.md](CONTRIBUTING.md#setup-with-hatch)
+
+## Basic Usage
+
+To read in an eqdsk (json or eqdsk) in its raw state:
+```python
+from eqdsk import EQDSKInterface
+
+EQDSKInterface.from_file('file.json', no_cocos=True)
+```
+To read in an eqdsk file with a known cocos format and convert it to a given cocos format:
+```python
+EQDSKInterface.from_file('file.eqdsk', from_cocos=11, to_cocos=17)
+```
+Alternatively if the direction (clockwise or anticlockwise) and the units of phi (V.s or V.s/rad) are known,
+the cocos standard will be calculated for you:
+```python
+EQDSKInterface.from_file('file.eqdsk', clockwise_phi=True, volt_seconds_per_radian=True)
+```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Hatch project](https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg)](https://github.com/pypa/hatch)
 [![linting - Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![Actions status](https://github.com/Fusion-Power-Plant-Framework/eqdsk/actions/workflows/push-main.yml/badge.svg)](https://github.com//Fusion-Power-Plant-Framework/eqdsk/actions)
+[![Actions status](https://github.com/Fusion-Power-Plant-Framework/eqdsk/actions/workflows/main.yml/badge.svg)](https://github.com//Fusion-Power-Plant-Framework/eqdsk/actions)
 
 An EQDSK reader and writer for GEQDSK (more soon), with COCOS identification and conversion.
 

--- a/eqdsk/cocos.py
+++ b/eqdsk/cocos.py
@@ -345,9 +345,7 @@ def identify_cocos(
 
     sign_Ip = Sign(np.sign(plasma_current))
     sign_B0 = Sign(np.sign(b_toroidal))
-    sign_psi_inc_towards_boundary = Sign(
-        np.sign(psi_at_boundary - psi_at_mag_axis)
-    )
+    sign_psi_inc_towards_boundary = Sign(np.sign(psi_at_boundary - psi_at_mag_axis))
 
     sign_q = np.sign(q_psi)
     if sign_q.min() != sign_q.max():

--- a/eqdsk/cocos.py
+++ b/eqdsk/cocos.py
@@ -275,16 +275,12 @@ def identify_eqdsk(
         A list of the identified COCOS definitions.
     """
     if eqdsk.qpsi is None:
-        eqdsk_warn(
-            "WARNING: qpsi is not defined in the eqdsk file. Setting to 1"
-        )
+        eqdsk_warn("WARNING: qpsi is not defined in the eqdsk file. Setting to 1")
         eqdsk.qpsi = np.array([1])
 
     cw_phi_l = [True, False] if clockwise_phi is None else [clockwise_phi]
     vs_pr_l = (
-        [True, False]
-        if volt_seconds_per_radian is None
-        else [volt_seconds_per_radian]
+        [True, False] if volt_seconds_per_radian is None else [volt_seconds_per_radian]
     )
 
     definitions = [
@@ -371,9 +367,7 @@ def identify_cocos(
     )
 
 
-def transform_cocos(
-    from_cocos_index: int, to_cocos_index: int
-) -> COCOSTransform:
+def transform_cocos(from_cocos_index: int, to_cocos_index: int) -> COCOSTransform:
     """Return the transformation needed to transform from one COCOS
     to another.
     """

--- a/eqdsk/file.py
+++ b/eqdsk/file.py
@@ -48,7 +48,6 @@ class EQDSKInterface:
     """
 
     DEFAULT_COCOS_INDEX = 11
-    suggestion = False
 
     bcentre: float
     """Vacuum toroidal Magnetic field at the reference radius [T]."""
@@ -298,11 +297,10 @@ class EQDSKInterface:
             json_kwargs = {} if json_kwargs is None else json_kwargs
             json_writer(self.to_dict(), file_path, **json_kwargs)
         elif file_format in {"eqdsk", "geqdsk"}:
-            if self.suggestion:
-                eqdsk_warn(
-                    "You are in the 21st century. "
-                    "Are you sure you want to be making an EDQSK in this day and age?"
-                )
+            eqdsk_warn(
+                "You are in the 21st century. "
+                "Are you sure you want to be making an EDQSK in this day and age?"
+            )
             _write_eqdsk(file_path, self.to_dict())
 
     def update(self, eqdsk_data: dict[str, Any]):

--- a/eqdsk/file.py
+++ b/eqdsk/file.py
@@ -602,14 +602,15 @@ def _write_eqdsk(file_path: str | Path, data: dict):
 
         # Define dummy data for qpsi if it has not been previously defined.
         qpsi = (
-            np.zeros(data["nx"]) if data["qpsi"] is None else np.atleast_1d(data["qpsi"])
+            np.ones(data["nx"]) if data["qpsi"] is None else np.atleast_1d(data["qpsi"])
         )
 
         if len(qpsi) == 1:
             qpsi = np.full(data["nx"], qpsi)
         elif len(qpsi) != data["nx"]:
-            eqdsk_warn("qpsi length not equal to nx, padding with 0")
-            qpsi = np.pad(qpsi, (0, data["nx"] - len(qpsi)))
+            raise ValueError(
+                "the length of qpsi should be 1 or the number of x grid points"
+            )
 
         # Create array containing coilset information.
         coil = np.zeros(5 * data["ncoil"])

--- a/eqdsk/file.py
+++ b/eqdsk/file.py
@@ -526,7 +526,7 @@ def _write_eqdsk(file_path: str | Path, data: dict):
     """
     file_path = Path(file_path)
     if file_path.suffix not in EQDSK_EXTENSIONS:
-        file_path = Path(file_path).with_suffix(".eqdsk")
+        file_path = file_path.with_suffix(".eqdsk")
 
     with Path(file_path).open("w") as file:
 

--- a/eqdsk/tools.py
+++ b/eqdsk/tools.py
@@ -84,7 +84,7 @@ def is_num(thing) -> bool:
     num:
         Whether or not the input is a number
     """
-    if thing is True or thing is False:
+    if thing in {True, False}:
         return False
     try:
         thing = floatify(thing)

--- a/eqdsk/tools.py
+++ b/eqdsk/tools.py
@@ -4,6 +4,7 @@
 """Eqdsk tools"""
 
 from json import JSONEncoder, dumps
+from pathlib import Path
 
 import numpy as np
 import numpy.typing as npt
@@ -25,7 +26,7 @@ class NumpyJSONEncoder(JSONEncoder):
 
 def json_writer(
     data: dict,
-    file: str | None = None,
+    file: str | Path | None = None,
     *,
     return_output: bool = False,
     cls=NumpyJSONEncoder,
@@ -57,6 +58,10 @@ def json_writer(
     the_json = dumps(data, cls=cls, **kwargs)
 
     if file is not None:
+        file = Path(file)
+        if file.suffix != ".json":
+            file = Path(file).with_suffix(".json")
+
         with open(file, "w") as fh:
             fh.write(the_json)
             fh.write("\n")

--- a/eqdsk/tools.py
+++ b/eqdsk/tools.py
@@ -60,7 +60,7 @@ def json_writer(
     if file is not None:
         file = Path(file)
         if file.suffix != ".json":
-            file = Path(file).with_suffix(".json")
+            file = file.with_suffix(".json")
 
         with open(file, "w") as fh:
             fh.write(the_json)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ python = ["3.10", "3.11", "3.12"]
 [tool.hatch.envs.test.scripts]
 tests      = "pytest {args:tests}"
 tests-cov  = "pytest --cov eqdsk  --cov-report html:htmlcov_eqdsk --cov-report xml {args:tests}"
+tests-cov-private  = "pytest --private --cov eqdsk --cov-report html:htmlcov --cov-report xml {args:tests}"
 
 # env: docs
 [tool.hatch.envs.docs]
@@ -117,7 +118,6 @@ ignore = [
   "PTH123",  # use Path.open
   "TRY003",  # put error messages in error class
   "FURB152", # 3.14 != pi
-  "PIE790",  # TMP for false positive ...
 ]
 
 [tool.ruff.lint.isort]
@@ -141,6 +141,9 @@ convention = "numpy"
   "D104",
   "ERA001",
   "PLR2004",
+  "PLR0912",
+  "PLR0914",
+  "N802",
   "S101",
   "TID252",
 ]
@@ -168,3 +171,4 @@ addopts        = "--html=report.html --self-contained-html --strict-markers -r f
 log_cli        = true
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s"
 log_cli_level  = "INFO"
+markers = ["private: Tests using private data"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ all    = ["style", "typing"]
 # tool: ruff
 [tool.ruff]
 target-version = "py310"
-line-length = 80
+line-length = 89
 exclude = [
   ".git",
   "__pycache__",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023-present The Bluemira Developers <https://github.com/Fusion-Power-Plant-Framework/bluemira>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: 2023-present The Bluemira Developers <https://github.com/Fusion-Power-Plant-Framework/bluemira>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import operator
+from pathlib import Path
+from typing import Any
+
+import fortranformat as ff
+import numpy as np
+
+from eqdsk.tools import is_num
+
+
+def get_private_dir():
+    """Get private data directory"""
+    if (private_data := Path(__file__).parent / "test_data" / "private").is_dir():
+        return private_data
+    if (
+        private_data := Path(__file__).parent.parent.parent / "bluemira-private-data"
+    ).is_dir():
+        return private_data
+    return None
+
+
+def read_strict_geqdsk(file_path):
+    """
+    Reads an input EQDSK file in, assuming strict adherence to the
+    GEQDSK format. Used to check bluemira outputs can be read by
+    external readers.
+
+    Note: The main bluemira GEQDSK reader is more forgiving to
+    format variations than this!
+
+    Parameters
+    ----------
+    file_path: str
+        Full path string of the file
+
+    """
+    # Create FortranRecordReader objects with the Fortran format
+    # edit descriptors to be used to parse the G-EQDSK input.
+    f2000 = ff.FortranRecordReader("a48,3i4")
+    f2020 = ff.FortranRecordReader("5e16.9")
+    f2022 = ff.FortranRecordReader("2i5")
+    fCSTM = ff.FortranRecordReader("i5")
+
+    # Define helper function to read in flattened arrays.
+    def read_flat_array(fortran_format, array_size):
+        """
+        Reads in a flat (1D) numpy array from a G-EQDSK file.
+
+        Parameters
+        ----------
+        fortran_format: ff.FortranRecordReader
+            FortranRecordReader object for Fortran format edit descriptor
+            to be used to parse the format of each line of the output.
+        array_size: int
+            Number of elements in array to be read in.
+
+        Returns
+        -------
+        array: np.array
+            1D Numpy array of length array_size populated by elements from
+            the GEQDSK file input.
+        """
+        # Initialise numpy array and read in first line.
+        array = np.zeros((array_size,))
+        line = fortran_format.read(file.readline())
+        # Define a counter to track which column in a line
+        # is currently being saved into the array.
+        col = 0
+        # Populate array. If the column index moves past the
+        # end of a line, it is reset to zero and the next line is read.
+        for i in range(array_size):
+            if col == len(line):
+                line = fortran_format.read(file.readline())
+                col = 0
+            array[i] = line[col]
+            col += 1
+        return array
+
+    # Open file.
+    with open(file_path) as file:
+        # Read in data. Variable names are for readability;
+        # strict format is as defined at
+        # https://w3.pppl.gov/ntcc/TORAY/G_EQDSK.pdf
+        _id, _, nx, nz = f2000.read(file.readline())
+        _xdim, _zdim, _xcentre, _xgrid1, _zmid = f2020.read(file.readline())
+        _xmag, _zmag, _psimag, _psibdry, _bcentre = f2020.read(file.readline())
+        _cplasma, _psimag, _, _xmag, _ = f2020.read(file.readline())
+        _zmag, _, _psibdry, _, _ = f2020.read(file.readline())
+        _fpol = read_flat_array(f2020, nx)
+        _pressure = read_flat_array(f2020, nx)
+        _ffprime = read_flat_array(f2020, nx)
+        _pprime = read_flat_array(f2020, nx)
+        _psi = read_flat_array(f2020, nx * nz)
+        _qpsi = read_flat_array(f2020, nx)
+        nbdry, nlim = f2022.read(file.readline())
+        _xbdry_zbdry = read_flat_array(f2020, 2 * nbdry)
+        _xlim_zlim = read_flat_array(f2020, 2 * nlim)
+
+        # Read in coil information, as found in the GEQDSK extension
+        (ncoil,) = fCSTM.read(file.readline())
+        _coil = read_flat_array(f2020, 5 * ncoil)
+
+
+def compare_dicts(
+    d1: dict[str, Any],
+    d2: dict[str, Any],
+    *,
+    almost_equal: bool = False,
+    verbose: bool = True,
+    rtol: float = 1e-5,
+    atol: float = 1e-8,
+) -> bool:
+    """
+    Compares two dictionaries. Will print information about the differences
+    between the two to the console. Dictionaries are compared by length, keys,
+    and values per common keys
+
+    Parameters
+    ----------
+    d1:
+        The reference dictionary
+    d2:
+        The dictionary to be compared with the reference
+    almost_equal:
+        Whether or not to use np.isclose and np.allclose for numbers and arrays
+    verbose:
+        Whether or not to print to the console
+    rtol:
+        The relative tolerance parameter, used if ``almost_equal`` is True
+    atol:
+        The absolute tolerance parameter, used if ``almost_equal`` is True
+
+    Returns
+    -------
+    Whether or not the dictionaries are the same
+    """
+    nkey_diff = len(d1) - len(d2)
+    k1 = set(d1.keys())
+    k2 = set(d2.keys())
+    intersect = k1.intersection(k2)
+    new_diff = k1 - k2
+    old_diff = k2 - k1
+    same, different = [], []
+
+    # Define functions to use for comparison in either the array, dict, or
+    # numeric cases.
+    def dict_eq(value_1, value_2):
+        return compare_dicts(
+            value_1,
+            value_2,
+            almost_equal=almost_equal,
+            verbose=verbose,
+            rtol=rtol,
+            atol=atol,
+        )
+
+    def array_almost_eq(val1, val2):
+        return np.allclose(val1, val2, rtol, atol)
+
+    def num_almost_eq(val1, val2):
+        return np.isclose(val1, val2, rtol, atol)
+
+    def array_is_eq(val1, val2):
+        return (np.asarray(val1) == np.asarray(val2)).all()
+
+    if almost_equal:
+        array_eq = array_almost_eq
+        num_eq = num_almost_eq
+    else:
+        array_eq = array_is_eq
+        num_eq = operator.eq
+
+    # Map the comparison functions to the keys based on the type of value in d1.
+    comp_map = {
+        key: (
+            array_eq
+            if isinstance(val, np.ndarray | list)
+            else (
+                dict_eq
+                if isinstance(val, dict)
+                else num_eq
+                if is_num(val)
+                else operator.eq
+            )
+        )
+        for key, val in d1.items()
+    }
+
+    # Do the comparison
+    for k in intersect:
+        v1, v2 = d1[k], d2[k]
+        try:
+            if comp_map[k](v1, v2):
+                same.append(k)
+            else:
+                different.append(k)
+        except ValueError:  # One is an array and the other not
+            different.append(k)
+
+    the_same = False
+    result = "===========================================================\n"
+    if nkey_diff != 0:
+        compare = "more" if nkey_diff > 0 else "fewer"
+        result += f"d1 has {nkey_diff} {compare} keys than d2" + "\n"
+    if new_diff != set():
+        result += "d1 has the following keys which d2 does not have:\n"
+        new_diff = ["\t" + str(i) for i in new_diff]
+        result += "\n".join(new_diff) + "\n"
+    if old_diff != set():
+        result += "d2 has the following keys which d1 does not have:\n"
+        old_diff = ["\t" + str(i) for i in old_diff]
+        result += "\n".join(old_diff) + "\n"
+    if different:
+        result += "the following shared keys have different values:\n"
+        different = ["\t" + str(i) for i in different]
+        result += "\n".join(different) + "\n"
+    if nkey_diff == 0 and new_diff == set() and old_diff == set() and different == []:
+        the_same = True
+    else:
+        result += "==========================================================="
+        if verbose:
+            print(result)  # noqa: T201
+    return the_same

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2023-present The Bluemira Developers <https://github.com/Fusion-Power-Plant-Framework/bluemira>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from tests._helpers import get_private_dir
+
+
+def pytest_addoption(parser):
+    """
+    Adds a custom command line option to pytest.
+    """
+    parser.addoption(
+        "--private",
+        action="store_true",
+        dest="private",
+        default=False,
+        help="run tests that use private data",
+    )
+
+
+def pytest_configure(config):
+    """
+    Configures pytest.
+    """
+    if config.option.private and get_private_dir() is None:
+        raise ValueError("You cannot run private tests. Data directory not found")
+
+    config.option.markexpr = "" if config.option.private else "not private"

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -134,28 +134,17 @@ class TestEQDSKInterface:
         assert compare_dicts(d1, d3, verbose=True)
         assert compare_dicts(d2, d3, verbose=True)
 
-    def test_read_strict_with_padding(self, tmp_path, caplog):
+    def test_write_with_wrong_length_qsi_raises_ValueError(self, tmp_path):
         file = self.data_dir / "DN-DEMO_eqref.json"
         # Create EQDSK file interface and read data to a dict
 
         eqdsk = EQDSKInterface.from_file(file, from_cocos_index=17, to_cocos_index=11)
         eqdsk.qpsi = np.ones(2)
 
-        # Write data read in from test file into a new EQDSK
-        # file, with the suffix "_temp"
-        name = Path(file).stem + "_temp"
-        fname = Path(tmp_path, f"{name}.eqdsk")
-
-        caplog.clear()
-        eqdsk.write(fname, file_format="eqdsk")
-        lg = caplog.records[-1]
-        assert lg.levelname == "WARNING"
-        assert "qpsi length not equal to nx" in lg.message
-
-        # Check eqdsk is readable by Fortran readers.
-        # This demands stricter adherence to the G-EQDSK
-        # format than eqdsk's main reader.
-        read_strict_geqdsk(fname)
+        with pytest.raises(ValueError, match="the length"):
+            eqdsk.write(
+                Path(tmp_path, f"{Path(file).stem}_temp.eqdsk"), file_format="eqdsk"
+            )
 
     @staticmethod
     @pytest.mark.private()

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -2,11 +2,22 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+import filecmp
 from pathlib import Path
 
 import pytest
 
 from eqdsk.file import EQDSKInterface
+
+
+def private_files():
+    """Get private files"""
+    file_path = Path(__file__).parent / "test_data" / "private" / "equilibria"
+
+    return [
+        (p, "eqdsk", 17 if "jetto" in p.as_posix() else 11)
+        for p in file_path.rglob("*eqdsk*")
+    ] + [(p, "json", 11) for p in file_path.rglob("*json")]
 
 
 class TestEQDSKInterface:
@@ -16,17 +27,39 @@ class TestEQDSKInterface:
     def setup_class(cls):
         cls.data_dir = Path(__file__).parent / "test_data"
 
-    def test_read_strict_geqdsk(self):
+    def test_read_strict_geqdsk(self, caplog):
         """Read and return the COCOS for the eqdsk."""
+        caplog.set_level("INFO")
+
         eqd_default = EQDSKInterface.from_file(
             self.data_dir / "jetto.eqdsk_out",
         )
+
+        logs = caplog.records
+        assert logs[0].levelname == "WARNING"
+        assert "(7, 8, 17, 18)" in logs[0].message
+        assert all(lg.levelname == "INFO" for lg in logs[1:])
+        assert all(
+            int(lg.message.split("COCOS")[-1].strip(".")) == ind
+            for lg, ind in zip(logs[1:], [7, 11, 11], strict=True)
+        )
+        caplog.clear()
+
         eqd_as_cc_2 = EQDSKInterface.from_file(
             self.data_dir / "jetto.eqdsk_out",
             volt_seconds_per_radian=True,
             clockwise_phi=True,
             to_cocos_index=2,
         )
+
+        logs = caplog.records
+        assert all(lg.levelname == "INFO" for lg in logs)
+        assert all(
+            int(lg.message.split("COCOS")[-1].strip(".")) == ind
+            for lg, ind in zip(logs, [8, 2, 2], strict=True)
+        )
+        caplog.clear()
+
         eqd_no_cc = EQDSKInterface.from_file(
             self.data_dir / "jetto.eqdsk_out",
             no_cocos=True,
@@ -34,6 +67,29 @@ class TestEQDSKInterface:
 
         assert eqd_default.cocos.index == EQDSKInterface.DEFAULT_COCOS_INDEX
         assert eqd_as_cc_2.cocos.index == 2
+        assert caplog.records == []
 
         with pytest.raises(ValueError):  # noqa: PT011
             eqd_no_cc.cocos  # noqa: B018
+
+    @pytest.mark.parametrize(
+        ("file", "ftype", "ind"),
+        [("jetto.eqdsk_out", "eqdsk", 17), ("DN-DEMO_eqref.json", "json", 11)],
+    )
+    def test_read_write_doesnt_change_file(self, file, ftype, ind, tmp_path):
+        eqd_default = EQDSKInterface.from_file(self.data_dir / file, ind)
+
+        eqd_default.write(tmp_path / "test", file_format=ftype)
+
+        filecmp.cmp(self.data_dir / file, tmp_path / f"test.{ftype}", shallow=False)
+
+    @staticmethod
+    @pytest.mark.parametrize(("file", "ftype", "ind"), private_files())
+    def test_read_write_doesnt_change_file_private(file, ftype, ind, tmp_path):
+        path = tmp_path / "private"
+        path.mkdir()
+        eqd_default = EQDSKInterface.from_file(file, ind)
+
+        eqd_default.write(path / "test", file_format=ftype)
+
+        filecmp.cmp(file, path / f"test.{ftype}", shallow=False)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -3,21 +3,32 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import filecmp
+import json
+from copy import deepcopy
 from pathlib import Path
+from unittest import mock
 
+import numpy as np
 import pytest
 
 from eqdsk.file import EQDSKInterface
+from tests._helpers import compare_dicts, get_private_dir, read_strict_geqdsk
 
 
 def private_files():
     """Get private files"""
-    file_path = Path(__file__).parent / "test_data" / "private" / "equilibria"
+    file_path = get_private_dir() / "equilibria"
+
+    def _cocos(pth):
+        pth = pth.as_posix()
+        if "jetto" in pth or "COCOS11" in pth:
+            return 11
+        return 17
 
     return [
-        (p, "eqdsk", 17 if "jetto" in p.as_posix() else 11)
-        for p in file_path.rglob("*eqdsk*")
-    ] + [(p, "json", 11) for p in file_path.rglob("*json")]
+        *((p, "eqdsk", _cocos(p)) for p in file_path.rglob("*eqdsk*")),
+        *((p, "json", _cocos(p)) for p in file_path.rglob("*json")),
+    ]
 
 
 class TestEQDSKInterface:
@@ -27,7 +38,7 @@ class TestEQDSKInterface:
     def setup_class(cls):
         cls.data_dir = Path(__file__).parent / "test_data"
 
-    def test_read_strict_geqdsk(self, caplog):
+    def test_read_default_cocos(self, caplog):
         """Read and return the COCOS for the eqdsk."""
         caplog.set_level("INFO")
 
@@ -37,14 +48,16 @@ class TestEQDSKInterface:
 
         logs = caplog.records
         assert logs[0].levelname == "WARNING"
-        assert "(7, 8, 17, 18)" in logs[0].message
+        assert "(1, 2, 11, 12)" in logs[0].message
         assert all(lg.levelname == "INFO" for lg in logs[1:])
         assert all(
             int(lg.message.split("COCOS")[-1].strip(".")) == ind
-            for lg, ind in zip(logs[1:], [7, 11, 11], strict=True)
+            for lg, ind in zip(logs[1:], [1, 11, 11], strict=True)
         )
-        caplog.clear()
 
+        assert eqd_default.cocos.index == EQDSKInterface.DEFAULT_COCOS_INDEX
+
+    def test_read_cocos_specified(self, caplog):
         eqd_as_cc_2 = EQDSKInterface.from_file(
             self.data_dir / "jetto.eqdsk_out",
             volt_seconds_per_radian=True,
@@ -53,28 +66,24 @@ class TestEQDSKInterface:
         )
 
         logs = caplog.records
-        assert all(lg.levelname == "INFO" for lg in logs)
-        assert all(
-            int(lg.message.split("COCOS")[-1].strip(".")) == ind
-            for lg, ind in zip(logs, [8, 2, 2], strict=True)
-        )
-        caplog.clear()
-
-        eqd_no_cc = EQDSKInterface.from_file(
-            self.data_dir / "jetto.eqdsk_out",
-            no_cocos=True,
-        )
-
-        assert eqd_default.cocos.index == EQDSKInterface.DEFAULT_COCOS_INDEX
+        assert logs[0].levelname == "INFO"
+        assert int(logs[0].message.split("COCOS")[-1].strip(".")) == 2
         assert eqd_as_cc_2.cocos.index == 2
-        assert caplog.records == []
 
-        with pytest.raises(ValueError):  # noqa: PT011
-            eqd_no_cc.cocos  # noqa: B018
+    def test_no_cocos_access_raise_ValueError(self):
+        with pytest.raises(ValueError, match="not yet been identified"):
+            EQDSKInterface.from_file(  # noqa: B018
+                self.data_dir / "jetto.eqdsk_out",
+                no_cocos=True,
+            ).cocos
 
     @pytest.mark.parametrize(
         ("file", "ftype", "ind"),
-        [("jetto.eqdsk_out", "eqdsk", 17), ("DN-DEMO_eqref.json", "json", 11)],
+        [
+            ("jetto.eqdsk_out", "eqdsk", 11),
+            ("DN-DEMO_eqref.json", "json", 17),
+            ("eqref_OOB.json", "json", 17),
+        ],
     )
     def test_read_write_doesnt_change_file(self, file, ftype, ind, tmp_path):
         eqd_default = EQDSKInterface.from_file(self.data_dir / file, ind)
@@ -83,13 +92,131 @@ class TestEQDSKInterface:
 
         filecmp.cmp(self.data_dir / file, tmp_path / f"test.{ftype}", shallow=False)
 
+    def test_read_wrong_cocos_raises_ValueError(self):
+        with pytest.raises(ValueError, match="No convention found"):
+            EQDSKInterface.from_file(self.data_dir / "jetto.eqdsk_out", 17)
+
+    @pytest.mark.parametrize(
+        ("setup_keys", "end_keys"),
+        [
+            ({"from_cocos_index": 17, "to_cocos_index": 11}, {"from_cocos_index": 11}),
+            ({"no_cocos": True}, {"no_cocos": True}),
+        ],
+    )
+    def test_read_strict_geqds(self, setup_keys, end_keys, tmp_path):
+        file = self.data_dir / "DN-DEMO_eqref.json"
+        # Create EQDSK file interface and read data to a dict
+
+        eqdsk = EQDSKInterface.from_file(file, **setup_keys)
+        d1 = eqdsk.to_dict()
+
+        # Write data read in from test file into a new EQDSK
+        # file, with the suffix "_temp"
+        name = Path(file).stem + "_temp"
+        fname = Path(tmp_path, f"{name}.eqdsk")
+        eqdsk.write(fname, file_format="eqdsk")
+        d2 = eqdsk.to_dict()
+
+        # Check eqdsk is readable by Fortran readers.
+        # This demands stricter adherence to the G-EQDSK
+        # format than eqdsk's main reader.
+        read_strict_geqdsk(fname)
+
+        # Write data read in from test file into a new JSON
+        # file, with the suffix "_temp"
+        jname = fname.with_suffix("").with_suffix(".json")
+        eqdsk.write(jname, file_format="json")
+        d3 = EQDSKInterface.from_file(jname, **end_keys).to_dict()
+
+        # Compare dictionaries to check data hasn't
+        # been changed.
+        assert compare_dicts(d1, d2, verbose=True)
+        assert compare_dicts(d1, d3, verbose=True)
+        assert compare_dicts(d2, d3, verbose=True)
+
+    def test_read_strict_with_padding(self, tmp_path, caplog):
+        file = self.data_dir / "DN-DEMO_eqref.json"
+        # Create EQDSK file interface and read data to a dict
+
+        eqdsk = EQDSKInterface.from_file(file, from_cocos_index=17, to_cocos_index=11)
+        eqdsk.qpsi = np.ones(2)
+
+        # Write data read in from test file into a new EQDSK
+        # file, with the suffix "_temp"
+        name = Path(file).stem + "_temp"
+        fname = Path(tmp_path, f"{name}.eqdsk")
+
+        caplog.clear()
+        eqdsk.write(fname, file_format="eqdsk")
+        lg = caplog.records[-1]
+        assert lg.levelname == "WARNING"
+        assert "qpsi length not equal to nx" in lg.message
+
+        # Check eqdsk is readable by Fortran readers.
+        # This demands stricter adherence to the G-EQDSK
+        # format than eqdsk's main reader.
+        read_strict_geqdsk(fname)
+
     @staticmethod
+    @pytest.mark.private()
     @pytest.mark.parametrize(("file", "ftype", "ind"), private_files())
     def test_read_write_doesnt_change_file_private(file, ftype, ind, tmp_path):
         path = tmp_path / "private"
-        path.mkdir()
+        path.mkdir(exist_ok=True)
         eqd_default = EQDSKInterface.from_file(file, ind)
 
         eqd_default.write(path / "test", file_format=ftype)
 
         filecmp.cmp(file, path / f"test.{ftype}", shallow=False)
+
+    def test_derived_field_is_calculated_if_not_given(self):
+        data_file = Path(self.data_dir, "DN-DEMO_eqref.json")
+        with open(data_file) as f:
+            eudemo_sof_data = json.load(f)
+
+        mod_sof_data = deepcopy(eudemo_sof_data)
+        for field in ["x", "z", "psinorm"]:
+            del mod_sof_data[field]
+
+        with mock.patch(
+            "pathlib.Path.open", new=mock.mock_open(read_data=json.dumps(mod_sof_data))
+        ):
+            eqdsk = EQDSKInterface.from_file("/some/file.json")
+
+        np.testing.assert_allclose(eqdsk.x, eudemo_sof_data["x"])
+        np.testing.assert_allclose(eqdsk.z, eudemo_sof_data["z"])
+        # The calculation used for psinorm has changed since the
+        # eudemo_sof_data was created - so we can't compare to that in
+        # this case.
+        np.testing.assert_allclose(
+            eqdsk.psinorm, np.linspace(0, 1, len(eudemo_sof_data["fpol"]))
+        )
+
+    def test_read_matches_values_in_file(self):
+        eq = EQDSKInterface.from_file(Path(self.data_dir, "jetto.eqdsk_out"))
+
+        assert eq.nz == 151
+        assert eq.nx == 151
+        assert eq.xdim == pytest.approx(3.14981545)
+        assert eq.ncoil == 0
+        assert eq.xc.size == 0
+        assert eq.nbdry == 72
+        np.testing.assert_allclose(
+            eq.xbdry[:3], [0.399993127e01, 0.399150254e01, 0.396906908e01]
+        )
+        np.testing.assert_allclose(
+            eq.zbdry[-3:], [-0.507187454e00, -0.240712636e00, 0.263892047e-01]
+        )
+
+    def test_failed_read_eqdsk(self):
+        with (
+            pytest.raises(OSError, match="Could not read"),
+            mock.patch("pathlib.Path.open", new=mock.mock_open(read_data="")),
+        ):
+            EQDSKInterface.from_file(Path(self.data_dir, "jetto.eqdsk_out"), 11)
+
+        with (
+            pytest.raises(OSError, match="Should be at least"),
+            mock.patch("pathlib.Path.open", new=mock.mock_open(read_data=" ")),
+        ):
+            EQDSKInterface.from_file(Path(self.data_dir, "jetto.eqdsk_out"), 11)


### PR DESCRIPTION
- Adds some basic usage data to the README.
- Pulls over some more tests from bluemira 
- Fixes 3 bugs
  1) old json eqdsks sometimes contain pnorm instead of psinorm
  2) fix eqdsk writing bug
  3) In the strict g-eqdsk standard qpsi must have the same length as nx. 
      - This is now enforced in an eqdsk file only
      - A choice should be made about the fill value, if qpsi is a single value we fill with that, if it is multiple we fill with 0 to the length of nx, if qpsi is None we fill with 0