### PR TITLE
Strict eqdsk precision

### DIFF
--- a/eqdsk/file.py
+++ b/eqdsk/file.py
@@ -283,6 +283,8 @@ class EQDSKInterface:
         file_path: str,
         file_format: str = "json",
         json_kwargs: dict | None = None,
+        *,
+        strict_spec: bool = True,
     ):
         """Write the EQDSK data to file in the given format.
 
@@ -296,6 +298,9 @@ class EQDSKInterface:
         json_kwargs:
             Key word arguments to pass to the ``json.dump`` call. Only
             used if ``format`` is 'json'.
+        strict_spec:
+            As https://w3.pppl.gov/ntcc/TORAY/G_EQDSK.pdf arrays have the format
+            5e16.9, disabling this changes the format to 5ES23.16e2
         """
         if file_format == "json":
             json_kwargs = {} if json_kwargs is None else json_kwargs
@@ -305,7 +310,7 @@ class EQDSKInterface:
                 "You are in the 21st century. "
                 "Are you sure you want to be making an EDQSK in this day and age?"
             )
-            _write_eqdsk(file_path, self.to_dict())
+            _write_eqdsk(file_path, self.to_dict(), strict_spec=strict_spec)
 
     def update(self, eqdsk_data: dict[str, Any]):
         """Update this object's data with values from a dictionary.
@@ -516,7 +521,7 @@ def _derive_psinorm(fpol) -> np.ndarray:
     return np.linspace(0, 1, len(fpol))
 
 
-def _write_eqdsk(file_path: str | Path, data: dict):
+def _write_eqdsk(file_path: str | Path, data: dict, *, strict_spec: bool = True):
     """Write data out to a text file in G-EQDSK format.
 
     Parameters
@@ -525,6 +530,9 @@ def _write_eqdsk(file_path: str | Path, data: dict):
         The full path string of the file to be created
     data:
         Dictionary of EQDSK data.
+    strict_spec:
+        As https://w3.pppl.gov/ntcc/TORAY/G_EQDSK.pdf arrays have the format
+        5e16.9, disabling this changes the format to 5ES23.16e2
     """
     file_path = Path(file_path)
     if file_path.suffix not in EQDSK_EXTENSIONS:
@@ -622,7 +630,7 @@ def _write_eqdsk(file_path: str | Path, data: dict):
         # Create FortranRecordWriter objects with the Fortran format
         # edit descriptors to be used in the G-EQDSK output.
         f2000 = ff.FortranRecordWriter("a48,3i4")
-        f2020 = ff.FortranRecordWriter("5e16.9")
+        f2020 = ff.FortranRecordWriter("5e16.9" if strict_spec else "5ES23.16e2")
         f2022 = ff.FortranRecordWriter("2i5")
         fCSTM = ff.FortranRecordWriter("i5")
 

--- a/eqdsk/file.py
+++ b/eqdsk/file.py
@@ -622,7 +622,7 @@ def _write_eqdsk(file_path: str | Path, data: dict):
         # Create FortranRecordWriter objects with the Fortran format
         # edit descriptors to be used in the G-EQDSK output.
         f2000 = ff.FortranRecordWriter("a48,3i4")
-        f2020 = ff.FortranRecordWriter("5ES23.16e2")
+        f2020 = ff.FortranRecordWriter("5e16.9")
         f2022 = ff.FortranRecordWriter("2i5")
         fCSTM = ff.FortranRecordWriter("i5")
 
@@ -648,5 +648,6 @@ def _write_eqdsk(file_path: str | Path, data: dict):
 
         # Output of coilset information. This is an extension to the
         # regular eqdsk format.
-        write_line(fCSTM, ["ncoil"])
-        write_array(f2020, coil)
+        if data["ncoil"] > 0:
+            write_line(fCSTM, ["ncoil"])
+            write_array(f2020, coil)

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -41,7 +41,7 @@ def read_strict_geqdsk(file_path):
     # Create FortranRecordReader objects with the Fortran format
     # edit descriptors to be used to parse the G-EQDSK input.
     f2000 = ff.FortranRecordReader("a48,3i4")
-    f2020 = ff.FortranRecordReader("5ES23.16e2")
+    f2020 = ff.FortranRecordReader("5e16.9")
     f2022 = ff.FortranRecordReader("2i5")
     fCSTM = ff.FortranRecordReader("i5")
 

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -23,7 +23,7 @@ def get_private_dir():
     return None
 
 
-def read_strict_geqdsk(file_path):
+def read_strict_geqdsk(file_path, *, strict_spec=True):
     """
     Reads an input EQDSK file in, assuming strict adherence to the
     GEQDSK format. Used to check bluemira outputs can be read by
@@ -41,7 +41,7 @@ def read_strict_geqdsk(file_path):
     # Create FortranRecordReader objects with the Fortran format
     # edit descriptors to be used to parse the G-EQDSK input.
     f2000 = ff.FortranRecordReader("a48,3i4")
-    f2020 = ff.FortranRecordReader("5e16.9")
+    f2020 = ff.FortranRecordReader("5e16.9" if strict_spec else "5ES23.16e2")
     f2022 = ff.FortranRecordReader("2i5")
     fCSTM = ff.FortranRecordReader("i5")
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -180,7 +180,7 @@ class TestEQDSKInterface:
                 eqd_default.to_dict(), eqd_default_nc.to_dict(), verbose=True
             )
 
-        eqd_default.write(tmp_path / "test", file_format=ftype)
+        eqd_default.write(tmp_path / "test", file_format=ftype, strict_spec=False)
 
         eqd_test = EQDSKInterface.from_file(tmp_path / f"test.{ftype}", no_cocos=True)
         eqd_test_d = eqd_test.to_dict()


### PR DESCRIPTION
Some eqdsk we have seem to be out of spec unless the values are read in with enough precision.

This will revert the default but also allow for overly precise read in if required eg in tests