### PR TITLE
Specify COCOS from program names

### DIFF
--- a/.github/workflows/main_and_pr.yml
+++ b/.github/workflows/main_and_pr.yml
@@ -44,10 +44,16 @@ jobs:
           path: "./tests/test_data/private"
 
       - name: Run all tests with coverage
+        if: ${{ matrix.os != 'windows-latest'}}
         env:
           PRIVATE: ${{ github.event.pull_request.head.repo.fork  && 'tests-cov' || 'tests-cov-private' }}
         run: hatch run test:${PRIVATE}
 
+      - name: Run windows tests with coverage
+        if: ${{ matrix.os == 'windows-latest' }}
+        env:
+          PRIVATE: ${{ github.event.pull_request.head.repo.fork  && 'tests-cov' || 'tests-cov-private' }}
+        run: hatch run test:${env:PRIVATE}
   # docs:
   #   runs-on: ubuntu-latest
   #   steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         exclude: test_data
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.0
+    rev: v0.6.4
     hooks:
       - id: ruff
         args: [--fix]

--- a/eqdsk/cocos.py
+++ b/eqdsk/cocos.py
@@ -210,6 +210,48 @@ class COCOS(Enum):
 
         return next(filter(_match_cocos, cls))
 
+    @classmethod
+    def _missing_(cls, value) -> COCOS:
+        if isinstance(value, KnownCOCOS):
+            return value.cocos
+        if isinstance(value, str):
+            value = value.upper()
+            try:
+                try:
+                    return cls[value]
+                except KeyError:
+                    return KnownCOCOS[value].cocos
+            except KeyError:
+                raise ValueError(f"'{value}' not a known COCOS standard") from None
+        try:
+            value = int(value)
+        except ValueError:
+            raise ValueError(f"'{value}' not a known COCOS standard") from None
+        return cls.with_index(int(value))
+
+
+class KnownCOCOS(Enum):
+    """A enum of known COCOS outputs of codes"""
+
+    BLUEMIRA = (auto(), COCOS.C3)
+    JETTO = (auto(), COCOS.C11)
+    CREATE = (auto(), COCOS.C11)  # noqa: PIE796
+    FIESTA = (auto(), COCOS.C17)
+    IMAS = (auto(), COCOS.C1)
+
+    def __new__(cls, value: int, cocos: COCOS):
+        """A little hack to have different enums with the same COCOS
+
+        Returns
+        -------
+        :
+            The enum
+        """
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.cocos = cocos
+        return obj
+
 
 @dataclass(frozen=True)
 class COCOSTransform:

--- a/eqdsk/cocos.py
+++ b/eqdsk/cocos.py
@@ -170,7 +170,7 @@ class COCOS(Enum):
         Returns
         -------
         :
-            the COCOS of the given index.
+            The COCOS of the given index.
 
         Raises
         ------
@@ -195,7 +195,7 @@ class COCOS(Enum):
         Returns
         -------
         :
-            the COCOS matching the given parameters.
+            The COCOS matching the given parameters.
         """
 
         def _match_cocos(c: COCOS) -> bool:
@@ -393,7 +393,7 @@ def transform_cocos(from_cocos_index: int, to_cocos_index: int) -> COCOSTransfor
     Returns
     -------
     :
-        the transformation needed to transform from one COCOS
+        The transformation needed to transform from one COCOS
         to another.
     """
     in_cocos = COCOS.with_index(from_cocos_index)

--- a/eqdsk/cocos.py
+++ b/eqdsk/cocos.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass
-from enum import Enum, unique
+from enum import Enum, auto, unique
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -166,7 +166,17 @@ class COCOS(Enum):
 
     @classmethod
     def with_index(cls, cocos_index: int) -> COCOS:
-        """Return the COCOS of the given index."""
+        """
+        Returns
+        -------
+        :
+            the COCOS of the given index.
+
+        Raises
+        ------
+        ValueError
+            COCOS format not known
+        """
         if not (cocos_index in range(1, 9) or cocos_index in range(11, 19)):
             msg = f"Convention number {cocos_index} is not valid. "
             "Must be between 1 and 8 or 11 and 18."
@@ -181,7 +191,12 @@ class COCOS(Enum):
         sign_R_phi_Z: Sign,
         sign_rho_theta_phi: Sign,
     ) -> COCOS:
-        """Return the COCOS matching the given parameters."""
+        """
+        Returns
+        -------
+        :
+            the COCOS matching the given parameters.
+        """
 
         def _match_cocos(c: COCOS) -> bool:
             return all(
@@ -235,6 +250,7 @@ def identify_eqdsk(
 
     Returns
     -------
+    :
         A list of the identified COCOS definitions.
     """
     if eqdsk.qpsi is None:
@@ -296,11 +312,13 @@ def identify_cocos(
 
     Returns
     -------
-    The identified COCOS convention.
+    :
+        The identified COCOS convention.
 
     Raises
     ------
-    ValueError: If the sign of qpsi is not consistent across the flux
+    ValueError
+        If the sign of qpsi is not consistent across the flux
         surfaces.
     """
     sign_R_phi_Z = Sign.NEGATIVE if phi_clockwise_from_top else Sign.POSITIVE
@@ -329,8 +347,12 @@ def identify_cocos(
 
 
 def transform_cocos(from_cocos_index: int, to_cocos_index: int) -> COCOSTransform:
-    """Return the transformation needed to transform from one COCOS
-    to another.
+    """
+    Returns
+    -------
+    :
+        the transformation needed to transform from one COCOS
+        to another.
     """
     in_cocos = COCOS.with_index(from_cocos_index)
     out_cocos = COCOS.with_index(to_cocos_index)
@@ -359,7 +381,19 @@ def transform_cocos(from_cocos_index: int, to_cocos_index: int) -> COCOSTransfor
 
 
 def convert_eqdsk(eqdsk: EQDSKInterface, to_cocos_index: int) -> EQDSKInterface:
-    """Convert an eqdsk file to the given COCOS."""
+    """
+    Convert an eqdsk file to the given COCOS.
+
+    Returns
+    -------
+    :
+        The transformed eqdsk
+
+    Raises
+    ------
+    RuntimeError
+        Unable to convert to COCOS format
+    """
     in_eqdsk = eqdsk
     out_eqdsk = deepcopy(in_eqdsk)
 

--- a/eqdsk/file.py
+++ b/eqdsk/file.py
@@ -338,7 +338,7 @@ class EQDSKInterface:
         Returns
         -------
         :
-             a copy of this eqdsk converted to the given COCOS.
+             A copy of this eqdsk converted to the given COCOS.
 
         Note
         ----
@@ -355,7 +355,7 @@ class EQDSKInterface:
         Returns
         -------
         :
-            a dictionary of the EQDSK data.
+            A dictionary of the EQDSK data.
         """
         d = asdict(self)
         # Remove the file name as this is metadata, not EQDSK data

--- a/eqdsk/file.py
+++ b/eqdsk/file.py
@@ -25,6 +25,7 @@ from eqdsk.models import Sign
 from eqdsk.tools import is_num, json_writer
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from io import TextIOWrapper
 
 
@@ -185,7 +186,15 @@ class EQDSKInterface:
 
         Returns
         -------
+        :
             An instance of this class containing the EQDSK file's data.
+
+        Raises
+        ------
+        ValueError
+            Unknown file format
+        NoSingleConventionError
+            More than one COCOS convention identified
         """
         file_path = Path(file_path)
         file_extension = file_path.suffix
@@ -221,7 +230,13 @@ class EQDSKInterface:
 
     @property
     def cocos(self) -> COCOS:
-        """Return the COCOS for this eqdsk."""
+        """Return the COCOS for this eqdsk.
+
+        Raises
+        ------
+        ValueError
+            COCOS not identified
+        """
         if self._cocos is None:
             raise ValueError(
                 "The COCOS for this eqdsk has not yet been identified. "
@@ -261,11 +276,12 @@ class EQDSKInterface:
 
         Raises
         ------
-        ValueError:
+        ValueError
             If as_cocos is given but does not match any identified COCOS.
-        ValueError:
+        ValueError
             If no COCOS can be identified.
-
+        MissingQpsiDataError
+            qpsi not provided or found in file
         """
         qpsi_sign = qpsi_sign if qpsi_sign is None else Sign(qpsi_sign)
         qpsi_is_not_set = self.qpsi is None or np.allclose(self.qpsi, 0)
@@ -331,7 +347,12 @@ class EQDSKInterface:
         return convert_eqdsk(self, to_cocos)
 
     def to_dict(self) -> dict:
-        """Return a dictionary of the EQDSK data."""
+        """
+        Returns
+        -------
+        :
+            a dictionary of the EQDSK data.
+        """
         d = asdict(self)
         # Remove the file name as this is metadata, not EQDSK data
         del d["file_name"]
@@ -381,7 +402,7 @@ class EQDSKInterface:
 
         Raises
         ------
-         ValueError:
+        ValueError
             If a key in `eqdsk_data` does not correspond to an
             attribute of this class.
         """
@@ -430,7 +451,7 @@ def _read_2d_array(tokens, n_x, n_y, name="Unknown") -> np.ndarray:
     return np.transpose(data)
 
 
-def _eqdsk_generator(file: TextIOWrapper):
+def _eqdsk_generator(file: TextIOWrapper) -> Iterator[str]:
     """Transform a file object into a generator, following G-EQDSK number
     conventions.
 
@@ -439,9 +460,10 @@ def _eqdsk_generator(file: TextIOWrapper):
     file:
         The file to read
 
-    Returns
-    -------
-        The generator of the file handle being read
+    Yields
+    ------
+    :
+        The lines of the file
     """
     while True:
         line = file.readline()
@@ -592,6 +614,11 @@ def _write_eqdsk(file_path: str | Path, data: dict, *, strict_spec: bool = True)
     strict_spec:
         As https://w3.pppl.gov/ntcc/TORAY/G_EQDSK.pdf arrays have the format
         5e16.9, disabling this changes the format to 5ES23.16e2
+
+    Raises
+    ------
+    ValueError
+        Length of qpsi is not consistent with the number of grid points
     """
     file_path = Path(file_path)
     if file_path.suffix not in EQDSK_EXTENSIONS:

--- a/eqdsk/models.py
+++ b/eqdsk/models.py
@@ -17,10 +17,16 @@ class ZeroOne(Enum):
     ONE = 1
 
     def __sub__(self, other: Any) -> ZeroOne:
-        """Return the difference between the value and the other value.
+        """
+        Returns
+        -------
+        :
+            The difference of the values as a new ZeroOne object
 
-        - If it is another ZeroOne, return the difference of the values.
-        - Raise a `TypeError` otherwise.
+        Raises
+        ------
+        TypeError
+            if not a ZeroOne object
         """
         if type(other) is ZeroOne:
             return ZeroOne(self.value - other.value)
@@ -37,9 +43,15 @@ class Sign(Enum):
     POSITIVE = 1
     NEGATIVE = -1
 
-    def __mul__(self, other: Any):
-        """Return the product of the sign with the other value.
+    def __mul__(self, other: Any) -> Sign | int:
+        """
+        Returns
+        -------
+        :
+            the product of the sign with the other value.
 
+        Notes
+        -----
         - If it is another Sign, return the product of the values.
         - If it is a number, return the product of the value and the number.
         """

--- a/eqdsk/models.py
+++ b/eqdsk/models.py
@@ -48,7 +48,7 @@ class Sign(Enum):
         Returns
         -------
         :
-            the product of the sign with the other value.
+            The product of the sign with the other value.
 
         Notes
         -----

--- a/eqdsk/tools.py
+++ b/eqdsk/tools.py
@@ -22,7 +22,7 @@ class NumpyJSONEncoder(JSONEncoder):
         Returns
         -------
         :
-            object in a format json can handle
+            The object in a format json can handle
         """
         if isinstance(obj, np.ndarray):
             return obj.tolist()
@@ -55,7 +55,7 @@ def json_writer(
     Returns
     -------
     :
-        the json file as a string if requested else None
+        The json file as a string if requested else None
     """
     if file is None and not return_output:
         eqdsk_warn("No json action to take")

--- a/eqdsk/tools.py
+++ b/eqdsk/tools.py
@@ -18,6 +18,11 @@ class NumpyJSONEncoder(JSONEncoder):
     def default(self, obj):
         """Override the JSONEncoder default object handling behaviour
         for np.arrays.
+
+        Returns
+        -------
+        :
+            object in a format json can handle
         """
         if isinstance(obj, np.ndarray):
             return obj.tolist()
@@ -47,6 +52,10 @@ def json_writer(
     kwargs:
         all further kwargs passed to the json writer
 
+    Returns
+    -------
+    :
+        the json file as a string if requested else None
     """
     if file is None and not return_output:
         eqdsk_warn("No json action to take")
@@ -81,7 +90,7 @@ def is_num(thing) -> bool:
 
     Returns
     -------
-    num:
+    :
         Whether or not the input is a number
     """
     if thing in {True, False}:
@@ -102,6 +111,11 @@ def floatify(x: npt.ArrayLike) -> float:
     -----
     This function aims to avoid numpy warnings for float(x) for >0 rank scalars
     it emulates the functionality of float conversion
+
+    Returns
+    -------
+    :
+        The value as a float
 
     Raises
     ------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ ignore = [
   "D301",
   "D400",
   "D401",
+  "DOC502",  # Raises sections not in top level function
   "DTZ005",  # datetime timezone arg
   "E203",    # black/ruff format conflicts
   "FIX002",  # Line contains todo

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -8,12 +8,20 @@ from typing import Any
 
 import fortranformat as ff
 import numpy as np
+import numpy.typing as npt
 
 from eqdsk.tools import is_num
 
 
-def get_private_dir():
-    """Get private data directory"""
+def get_private_dir() -> Path | None:
+    """
+    Get private data directory
+
+    Returns
+    -------
+    :
+        The data directory if found
+    """
     if (private_data := Path(__file__).parent / "test_data" / "private").is_dir():
         return private_data
     if (
@@ -46,21 +54,23 @@ def read_strict_geqdsk(file_path, *, strict_spec=True):
     fCSTM = ff.FortranRecordReader("i5")
 
     # Define helper function to read in flattened arrays.
-    def read_flat_array(fortran_format, array_size):
+    def read_flat_array(
+        fortran_format: ff.FortranRecordReader, array_size: int
+    ) -> npt.NDArray:
         """
         Reads in a flat (1D) numpy array from a G-EQDSK file.
 
         Parameters
         ----------
-        fortran_format: ff.FortranRecordReader
+        fortran_format:
             FortranRecordReader object for Fortran format edit descriptor
             to be used to parse the format of each line of the output.
-        array_size: int
+        array_size:
             Number of elements in array to be read in.
 
         Returns
         -------
-        array: np.array
+        array:
             1D Numpy array of length array_size populated by elements from
             the GEQDSK file input.
         """
@@ -136,7 +146,8 @@ def compare_dicts(
 
     Returns
     -------
-    Whether or not the dictionaries are the same
+    :
+        Whether or not the dictionaries are the same
     """
     nkey_diff = len(d1) - len(d2)
     k1 = set(d1.keys())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,11 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     """
     Configures pytest.
+
+    Raises
+    ------
+    ValueError
+        Failed to find private data directory
     """
     if config.option.private and get_private_dir() is None:
         raise ValueError("You cannot run private tests. Data directory not found")

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -17,8 +17,14 @@ from eqdsk.models import Sign
 from tests._helpers import compare_dicts, get_private_dir, read_strict_geqdsk
 
 
-def private_files():
-    """Get private files"""
+def private_files() -> list[tuple[Path, str, int]]:
+    """Get private files
+
+    Returns
+    -------
+    :
+        the list of available private eqdsks their filetype and cocos format
+    """
     if (pdir := get_private_dir()) is None:
         return []
 
@@ -172,7 +178,7 @@ class TestEQDSKInterface:
             )
 
     @staticmethod
-    @pytest.mark.private()
+    @pytest.mark.private
     @pytest.mark.parametrize(("file", "ftype", "ind"), private_files())
     def test_read_write_doesnt_change_file_private(file, ftype, ind, tmp_path):
         path = tmp_path / "private"

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -23,7 +23,7 @@ def private_files() -> list[tuple[Path, str, int]]:
     Returns
     -------
     :
-        the list of available private eqdsks their filetype and cocos format
+        The list of available private eqdsks their filetype and cocos format
     """
     if (pdir := get_private_dir()) is None:
         return []

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -51,12 +51,13 @@ class TestEQDSKInterface:
     def setup_class(cls):
         cls.data_dir = Path(__file__).parent / "test_data"
 
-    def test_read_default_cocos(self, caplog):
+    @pytest.mark.parametrize("cocos", [11, "jetto", "C11"])
+    def test_read_default_cocos(self, cocos, caplog):
         """Read and return the COCOS for the eqdsk."""
         caplog.set_level("INFO")
 
         eqd_default = EQDSKInterface.from_file(
-            self.data_dir / "jetto.eqdsk_out", from_cocos=11
+            self.data_dir / "jetto.eqdsk_out", from_cocos=cocos
         )
 
         logs = caplog.records
@@ -265,3 +266,17 @@ class TestEQDSKInterface:
     def test_fail_identify_from_file(self):
         with pytest.raises(NoSingleConventionError):
             EQDSKInterface.from_file(Path(self.data_dir, "jetto.eqdsk_out"))
+
+    def test_failed_cocos_fmt(self):
+        with pytest.raises(ValueError, match="not a known"):
+            EQDSKInterface.from_file(
+                Path(self.data_dir, "jetto.eqdsk_out"), from_cocos="hi"
+            )
+        with pytest.raises(ValueError, match="not a known"):
+            EQDSKInterface.from_file(
+                Path(self.data_dir, "jetto.eqdsk_out"), from_cocos=b"hi"
+            )
+        with pytest.raises(ValueError, match="Convention number"):
+            EQDSKInterface.from_file(
+                Path(self.data_dir, "jetto.eqdsk_out"), from_cocos=10
+            )


### PR DESCRIPTION
This allows for users to specify the program the eqdsk came from rather than the raw COCOS format where known.

Also closes #24... 