### PR TITLE
Aliases for backwards compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics",
 ]
 
-dependencies = ["fortranformat", "numpy", "click"]
+dependencies = ["fortranformat", "numpy", "click", "pydantic>=2"]
 
 [project.urls]
 Source        = "https://github.com/Fusion-Power-Plant-Framework/eqdsk"

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -282,3 +282,18 @@ class TestEQDSKInterface:
             EQDSKInterface.from_file(
                 Path(self.data_dir, "jetto.eqdsk_out"), from_cocos=10
             )
+
+    def test_aliases_return_same_object(self):
+        file = self.data_dir / "DN-DEMO_eqref.json"
+
+        eqdsk = EQDSKInterface.from_file(
+            file, from_cocos=3, to_cocos=11, qpsi_positive=False
+        )
+
+        assert eqdsk.psinorm is eqdsk.pnorm
+        eqdsk.psinorm = np.array([10])
+        assert eqdsk.pnorm == np.array([10])
+        assert eqdsk.psinorm is eqdsk.pnorm
+        eqdsk.pnorm = np.array([5])
+        assert eqdsk.psinorm == np.array([5])
+        assert eqdsk.psinorm is eqdsk.pnorm


### PR DESCRIPTION
This adds the ability to set aliases for any of the dataclass entries. 

Pydantic is added as a dependency which is part of general effort to improve validation of our data and adds the alias functionality on init of the dataclass (https://docs.pydantic.dev/latest/concepts/dataclasses/).
Arbitrary types are required for the pydantic config to allow numpy array typing which could be done with further dependencies but that seemed a bit overkill. Maybe something to think about.

The decorator adds property r/w access through the same aliases which the raw pydantic dataclass doesnt do.


 