### PR TITLE
Convert wall IDS to ASSUMED_IMAS version

### DIFF
--- a/eqdsk/imas.py
+++ b/eqdsk/imas.py
@@ -75,10 +75,7 @@ def from_imas(  # noqa: PLR0914
     # It should not be an issue if the limiter is not in the database
     # handle it by not returning limiter quantities
     try:
-        # TODO(@timothy-nunn): https://github.com/Fusion-Power-Plant-Framework/eqdsk/issues/100
-        # this IDS should be converted to the assumed version but this causes
-        # an exception
-        wall_ids = db.get("wall")
+        wall_ids = convert_ids(db.get("wall"), ASSUMED_IMAS_VERSION)
         limiter = wall_ids.description_2d[0].limiter.unit[0].outline
 
         xlim = _unwrap_imas_value(limiter.r, default=np.array([]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ docs = [
 ]
 lint = ["ruff", "mypy"]
 cli = ["matplotlib"]
-imas = ["imas-python[netcdf]>=2.0"]
+imas = ["imas-python[netcdf]>=2.2.0"]
 
 [project.scripts]
 eqdsk = "eqdsk.cli:cli"


### PR DESCRIPTION
Waiting on a new release of IMAS-Python that includes a required bugfix (`>2.2`)