### PR TITLE
Resolves use of enforced qpsi sign alongside existing qprofiles in eqdsk

### DIFF
--- a/eqdsk/cocos.py
+++ b/eqdsk/cocos.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from eqdsk.models import Sign, ZeroOne
+from eqdsk.log import eqdsk_warn
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -314,11 +315,12 @@ def identify_eqdsk(
     ValueError
         If eqdsk.qpsi is None and qpsi_positive is not provided.
     """
-    if eqdsk.qpsi is None and qpsi_positive is None:
+    qpsi_is_not_set = eqdsk.qpsi is None or np.allclose(eqdsk.qpsi, 0)
+    if qpsi_is_not_set and qpsi_positive is None:
         raise ValueError(
             "eqdsk.qpsi is None, qpsi_positive must be provided.",
         )
-
+    q_psi = np.asarray(1 if qpsi_positive else -1) if qpsi_is_not_set else eqdsk.qpsi
     cw_phi_l = [True, False] if clockwise_phi is None else [clockwise_phi]
     vs_pr_l = (
         [True, False] if volt_seconds_per_radian is None else [volt_seconds_per_radian]
@@ -330,9 +332,7 @@ def identify_eqdsk(
             b_toroidal=eqdsk.bcentre,
             psi_at_boundary=eqdsk.psibdry,
             psi_at_mag_axis=eqdsk.psimag,
-            q_psi=np.asarray(1 if qpsi_positive else -1)
-            if eqdsk.qpsi is None
-            else eqdsk.qpsi,
+            q_psi=q_psi,
             phi_clockwise_from_top=cw_phi,
             volt_seconds_per_radian=vs_pr,
         )

--- a/eqdsk/cocos.py
+++ b/eqdsk/cocos.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from eqdsk.models import Sign, ZeroOne
-from eqdsk.log import eqdsk_warn
 
 if TYPE_CHECKING:
     import numpy.typing as npt

--- a/eqdsk/file.py
+++ b/eqdsk/file.py
@@ -405,9 +405,9 @@ Grid properties:
             qpsi not provided or found in file and qpsi_positive is not set.
         """
         qpsi_sign = None if qpsi_positive is None else Sign(qpsi_positive)
-        qpsi_is_not_set = self.qpsi is None or np.allclose(self.qpsi, 0)
 
-        if qpsi_is_not_set:
+        # if qpsi is not set
+        if self.qpsi is None or np.allclose(self.qpsi, 0):
             if qpsi_sign:
                 eqdsk_warn(
                     "eqdsk contains no qpsi data, but "

--- a/eqdsk/file.py
+++ b/eqdsk/file.py
@@ -434,6 +434,15 @@ Grid properties:
                     "You can also experiment by setting `qpsi_positive` and checking if "
                     "the resulting COCOS('s) is(are) correct.",
                 )
+        elif isinstance(qpsi_sign, Sign) and (np.sign(self.qpsi)[0] !=
+                                              qpsi_sign.value):
+            eqdsk_warn(
+                "Mismatch between eqdsk q sign and input q sign value."
+                f"The eqdsk q_psi sign of {np.sign(self.qpsi)[0]} will be"
+                f"overwritten with the input sign of {qpsi_sign.value}."
+                "This occurs because some codes used non-standard q signs."
+            )
+            self.qpsi *= -1
 
         conventions = identify_eqdsk(
             self,

--- a/eqdsk/file.py
+++ b/eqdsk/file.py
@@ -438,9 +438,9 @@ Grid properties:
                                               qpsi_sign.value):
             eqdsk_warn(
                 "Mismatch between eqdsk q sign and input q sign value."
-                f"The eqdsk q_psi sign of {np.sign(self.qpsi)[0]} will be"
-                f"overwritten with the input sign of {qpsi_sign.value}."
-                "This occurs because some codes used non-standard q signs."
+                f" The eqdsk q_psi sign of {np.sign(self.qpsi)[0]} will be"
+                f" overwritten with the input sign of {qpsi_sign.value}."
+                " This occurs because some codes used non-standard q signs."
             )
             self.qpsi *= -1
 

--- a/eqdsk/file.py
+++ b/eqdsk/file.py
@@ -434,8 +434,7 @@ Grid properties:
                     "You can also experiment by setting `qpsi_positive` and checking if "
                     "the resulting COCOS('s) is(are) correct.",
                 )
-        elif isinstance(qpsi_sign, Sign) and (np.sign(self.qpsi)[0] !=
-                                              qpsi_sign.value):
+        elif isinstance(qpsi_sign, Sign) and (np.sign(self.qpsi)[0] != qpsi_sign.value):
             eqdsk_warn(
                 "Mismatch between eqdsk q sign and input q sign value."
                 f" The eqdsk q_psi sign of {np.sign(self.qpsi)[0]} will be"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,3 +73,20 @@ def _plot_show_and_close(request):
             )
         plt.show()
         plt.close()
+
+
+@pytest.fixture
+def qsign_reference():
+    """
+    Qpsi reference values from Sauter paper
+    """  # noqa: DOC201
+    return {
+        1: True,
+        2: True,
+        3: False,
+        4: False,
+        5: False,
+        6: False,
+        7: True,
+        8: True,
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ import pytest
 from click.testing import CliRunner
 
 from eqdsk import cli
+from eqdsk.models import Sign
 
 
 @pytest.fixture(scope="module")
@@ -62,7 +63,8 @@ class TestCli:
         ("filename", "fc"), [("jetto.eqdsk_out", 1), ("DN-DEMO_eqref.json", 3)]
     )
     @staticmethod
-    def test_convert_eqdsk_with_from_to(filename, fc, to, data_folder):
+    def test_convert_eqdsk_with_from_to(filename, fc, to, data_folder, qsign_reference):
+        ind_red = fc - 10 if fc > 10 else fc
         result = cli_runner(
             cli.cli,
             [
@@ -74,7 +76,7 @@ class TestCli:
                 "-t",
                 f"{to}",
                 "-q",
-                "-1",
+                f"{Sign(qsign_reference[ind_red]).value}",
                 (data_folder / filename).as_posix(),
             ],
         )

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -221,23 +221,15 @@ class TestEQDSKInterface:
     @staticmethod
     @pytest.mark.private
     @pytest.mark.parametrize(("file", "ftype", "ind"), private_files())
-    def test_read_write_doesnt_change_file_private(file, ftype, ind, tmp_path):
+    def test_read_write_doesnt_change_file_private(
+        file, ftype, ind, tmp_path, qsign_reference
+    ):
         path = tmp_path / "private"
         path.mkdir(exist_ok=True)
-        ###
-        qpsi_sign = {
-            1: True,
-            2: True,
-            3: False,
-            4: False,
-            5: False,
-            6: False,
-            7: True,
-            8: True,
-        }
+
         ind_red = ind - 10 if ind > 10 else ind
         eqd_default = EQDSKInterface.from_file(
-            file, from_cocos=ind, qpsi_positive=qpsi_sign[ind_red]
+            file, from_cocos=ind, qpsi_positive=qsign_reference[ind_red]
         )
 
         if ind != 2 and "Random" not in file.name:

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -109,12 +109,17 @@ class TestEQDSKInterface:
     )
     def test_read_write_doesnt_change_file(self, file, ftype, ind, tmp_path, capsys):
         data_file = self.data_dir / file
+        eqd_default_nc = EQDSKInterface.from_file(data_file, no_cocos=True)
+        qpsi_sign = {
+            1: True,
+            3: False,
+            7: True
+        }
         eqd_default = EQDSKInterface.from_file(
             data_file,
             from_cocos=ind,
-            qpsi_positive=False,
+            qpsi_positive=qpsi_sign[ind],
         )
-        eqd_default_nc = EQDSKInterface.from_file(data_file, no_cocos=True)
         if ind != 11:
             assert not compare_dicts(
                 eqd_default.to_dict(), eqd_default_nc.to_dict(), verbose=True

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -112,13 +112,19 @@ class TestEQDSKInterface:
         eqd_default_nc = EQDSKInterface.from_file(data_file, no_cocos=True)
         qpsi_sign = {
             1: True,
+            2: True,
             3: False,
-            7: True
+            4: False,
+            5: False,
+            6: False,
+            7: True,
+            8: True,
         }
+        ind_red = ind - 10 if ind > 10 else ind
         eqd_default = EQDSKInterface.from_file(
             data_file,
             from_cocos=ind,
-            qpsi_positive=qpsi_sign[ind],
+            qpsi_positive=qpsi_sign[ind_red],
         )
         if ind != 11:
             assert not compare_dicts(
@@ -226,8 +232,20 @@ class TestEQDSKInterface:
     def test_read_write_doesnt_change_file_private(file, ftype, ind, tmp_path):
         path = tmp_path / "private"
         path.mkdir(exist_ok=True)
-
-        eqd_default = EQDSKInterface.from_file(file, from_cocos=ind, qpsi_positive=False)
+        ###
+        qpsi_sign = {
+            1: True,
+            2: True,
+            3: False,
+            4: False,
+            5: False,
+            6: False,
+            7: True,
+            8: True,
+        }
+        ind_red = ind - 10 if ind > 10 else ind
+        eqd_default = EQDSKInterface.from_file(file, from_cocos=ind,
+                                               qpsi_positive=qpsi_sign[ind_red])
 
         if ind != 2 and "Random" not in file.name:
             assert eqd_default.comment is None, len(eqd_default.comment)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -107,24 +107,16 @@ class TestEQDSKInterface:
             ("DN-DEMO_eqref_withCoilNames.json", None, 3),
         ],
     )
-    def test_read_write_doesnt_change_file(self, file, ftype, ind, tmp_path, capsys):
+    def test_read_write_doesnt_change_file(
+        self, file, ftype, ind, tmp_path, capsys, qsign_reference
+    ):
         data_file = self.data_dir / file
         eqd_default_nc = EQDSKInterface.from_file(data_file, no_cocos=True)
-        qpsi_sign = {
-            1: True,
-            2: True,
-            3: False,
-            4: False,
-            5: False,
-            6: False,
-            7: True,
-            8: True,
-        }
         ind_red = ind - 10 if ind > 10 else ind
         eqd_default = EQDSKInterface.from_file(
             data_file,
             from_cocos=ind,
-            qpsi_positive=qpsi_sign[ind_red],
+            qpsi_positive=qsign_reference[ind_red],
         )
         if ind != 11:
             assert not compare_dicts(
@@ -244,8 +236,9 @@ class TestEQDSKInterface:
             8: True,
         }
         ind_red = ind - 10 if ind > 10 else ind
-        eqd_default = EQDSKInterface.from_file(file, from_cocos=ind,
-                                               qpsi_positive=qpsi_sign[ind_red])
+        eqd_default = EQDSKInterface.from_file(
+            file, from_cocos=ind, qpsi_positive=qpsi_sign[ind_red]
+        )
 
         if ind != 2 and "Random" not in file.name:
             assert eqd_default.comment is None, len(eqd_default.comment)

--- a/tests/test_imas.py
+++ b/tests/test_imas.py
@@ -43,24 +43,24 @@ def _imas_hdf5_uri(tmp_path):
 )
 @pytest.mark.parametrize("file_format", ["imas", None])
 @pytest.mark.parametrize("imas_uri_fixture", ["_imas_netcdf_uri", "_imas_hdf5_uri"])
-def test_imas_write_read(
-    imas_uri_fixture, file, cocos, imas_dd_version, coil_comparison, file_format, request
+def test_imas_write_read(  # noqa: PLR0913, PLR0917
+    imas_uri_fixture,
+    file,
+    cocos,
+    imas_dd_version,
+    coil_comparison,
+    file_format,
+    request,
+    qsign_reference,
 ):
     """Test an eqdsk file can be read and then written to IMAS"""
     imas_uri = request.getfixturevalue(imas_uri_fixture)
-    qpsi_sign = {
-            1: True,
-            2: True,
-            3: False,
-            4: False,
-            5: False,
-            6: False,
-            7: True,
-            8: True,
-        }
     ind_red = cocos - 10 if cocos > 10 else cocos
     eqdsk = EQDSKInterface.from_file(
-        DATA_DIR / file, from_cocos=cocos, to_cocos=11, qpsi_positive=qpsi_sign[ind_red]
+        DATA_DIR / file,
+        from_cocos=cocos,
+        to_cocos=11,
+        qpsi_positive=qsign_reference[ind_red],
     )
 
     with DBEntry(imas_uri, "w", dd_version=imas_dd_version) as db:

--- a/tests/test_imas.py
+++ b/tests/test_imas.py
@@ -30,7 +30,7 @@ def _imas_hdf5_uri(tmp_path):
 
 @pytest.mark.parametrize(
     ("file", "cocos"),
-    [("jetto.eqdsk_out", "jetto"), ("DN-DEMO_eqref_withCoilNames.json", 3)],
+    [("jetto.eqdsk_out", 1), ("DN-DEMO_eqref_withCoilNames.json", 3)],
 )
 @pytest.mark.parametrize(
     ("imas_dd_version", "coil_comparison"),
@@ -48,9 +48,19 @@ def test_imas_write_read(
 ):
     """Test an eqdsk file can be read and then written to IMAS"""
     imas_uri = request.getfixturevalue(imas_uri_fixture)
-
+    qpsi_sign = {
+            1: True,
+            2: True,
+            3: False,
+            4: False,
+            5: False,
+            6: False,
+            7: True,
+            8: True,
+        }
+    ind_red = cocos - 10 if cocos > 10 else cocos
     eqdsk = EQDSKInterface.from_file(
-        DATA_DIR / file, from_cocos=cocos, to_cocos=11, qpsi_positive=False
+        DATA_DIR / file, from_cocos=cocos, to_cocos=11, qpsi_positive=qpsi_sign[ind_red]
     )
 
     with DBEntry(imas_uri, "w", dd_version=imas_dd_version) as db:


### PR DESCRIPTION
closes #112

Added changes to EQDSKInterface identify to handle overwriting the existing eqdsk qpsi with the desired sign using qsi_positive. Adds a warning that this overwrite is occurring.