### PR TITLE
Fix psinorm warning

### DIFF
--- a/eqdsk/file.py
+++ b/eqdsk/file.py
@@ -451,7 +451,8 @@ Grid properties:
                     f"Setting qpsi to array of {qpsi_sign.value}'s."
                 )
                 self.qpsi = (
-                    np.ones(num_psinorm_elements := self.psinorm.shape) * qpsi_sign.value
+                    np.ones(num_psinorm_elements := max(self.psinorm.shape))
+                    * qpsi_sign.value
                 )
                 if num_psinorm_elements != self.nx:
                     eqdsk_warn(


### PR DESCRIPTION
Taking just max(psinorm.shape) will work for (n,1) and (1,n) shape arrays